### PR TITLE
Fix Chrome 121 scrollbars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-primitive": "^1.0.3",
         "@radix-ui/react-roving-focus": "^1.0.4",
+        "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toolbar": "^1.0.4",
@@ -546,6 +547,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
@@ -924,6 +933,37 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz",
+      "integrity": "sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-primitive": "^1.0.3",
     "@radix-ui/react-roving-focus": "^1.0.4",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toolbar": "^1.0.4",

--- a/src/components/layout/BaseColorsSection/ColorListItem.tsx
+++ b/src/components/layout/BaseColorsSection/ColorListItem.tsx
@@ -24,7 +24,7 @@ const ColorListItem = ({
     title={
       <>
         <div
-          className='me-3 h-8 w-8 rounded-lg'
+          className='me-3 h-8 w-8 shrink-0 rounded-lg'
           style={{ backgroundColor: color }}
         />
         <ListItemText primary={title} secondary={color} />

--- a/src/components/layout/Options.tsx
+++ b/src/components/layout/Options.tsx
@@ -9,7 +9,7 @@ import { CodeGenSection } from './CodeGenSection';
 import { SheetWithFab } from './SheetWithFab';
 import { Sidebar } from './Sidebar';
 import { AccordionList } from '@/components/ui/AccordionList';
-import { ScrollArea } from '@/components//ui/ScrollArea';
+import { ScrollArea } from '@/components/ui/ScrollArea';
 import type { BaseColorsState } from '@/store/useBaseColors';
 import type { CodeGenState } from '@/store/useCodeGen';
 

--- a/src/components/layout/Options.tsx
+++ b/src/components/layout/Options.tsx
@@ -9,6 +9,7 @@ import { CodeGenSection } from './CodeGenSection';
 import { SheetWithFab } from './SheetWithFab';
 import { Sidebar } from './Sidebar';
 import { AccordionList } from '@/components/ui/AccordionList';
+import { ScrollArea } from '@/components//ui/ScrollArea';
 import type { BaseColorsState } from '@/store/useBaseColors';
 import type { CodeGenState } from '@/store/useCodeGen';
 
@@ -24,14 +25,12 @@ export const Options = () => {
     <>
       <Sidebar className='hidden md:flex print:hidden print:md:flex'>
         <Header className='px-4 py-2' />
-        <AccordionList
-          className='flex-grow overflow-y-auto pb-2 print:hidden'
-          value={openItem}
-          onValueChange={handleValueChange}
-        >
-          <BaseColorsSection />
-          <CodeGenSection />
-        </AccordionList>
+        <ScrollArea className='flex-grow pb-2 print:hidden'>
+          <AccordionList value={openItem} onValueChange={handleValueChange}>
+            <BaseColorsSection />
+            <CodeGenSection />
+          </AccordionList>
+        </ScrollArea>
       </Sidebar>
       <SheetWithFab
         label='Options'

--- a/src/components/layout/Options.tsx
+++ b/src/components/layout/Options.tsx
@@ -25,8 +25,7 @@ export const Options = () => {
       <Sidebar className='hidden md:flex print:hidden print:md:flex'>
         <Header className='px-4 py-2' />
         <AccordionList
-          className='flex-grow overflow-y-auto pb-2 scrollbar-thin
-scrollbar-thumb-neutral-500/30 print:hidden'
+          className='flex-grow overflow-y-auto pb-2 print:hidden'
           value={openItem}
           onValueChange={handleValueChange}
         >
@@ -40,8 +39,7 @@ scrollbar-thumb-neutral-500/30 print:hidden'
         onOpenChange={open => !open && setOpenItem(null)}
       >
         <AccordionList
-          className='pb-2 scrollbar-thin
-scrollbar-thumb-neutral-500/30 print:hidden'
+          className='pb-2'
           value={openItem}
           onValueChange={handleValueChange}
         >

--- a/src/components/ui/BottomSheet/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet/BottomSheet.tsx
@@ -11,6 +11,7 @@ import {
 } from '@radix-ui/react-dialog';
 
 import { H2 } from '../Headings';
+import { ScrollArea } from '../ScrollArea';
 import { cn } from '@/lib/utils';
 
 export type BottomSheetProps = ComponentPropsWithoutRef<'div'> &
@@ -40,11 +41,16 @@ dark:bg-card`,
           )}
         >
           {title && (
-            <DialogTitle asChild className='m-0 px-4 py-3'>
+            <DialogTitle
+              asChild
+              className='m-0 flex h-[3.75rem] flex-row items-center px-4'
+            >
               <H2>{title}</H2>
             </DialogTitle>
           )}
-          <div className='overflow-y-auto'>{children}</div>
+          <ScrollArea className='[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100dvh-7.75rem)]'>
+            {children}
+          </ScrollArea>
         </DialogContent>
       </DialogPortal>
     </Dialog>

--- a/src/components/ui/CodeBlock/CodeBlock.tsx
+++ b/src/components/ui/CodeBlock/CodeBlock.tsx
@@ -10,6 +10,7 @@ import { Highlight, Prism } from 'prism-react-renderer';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 
 import { IconButton } from '../IconButton';
+import { ScrollArea, ScrollBar } from '../ScrollArea';
 import { Tooltip } from '../Tooltip';
 import { cn } from '@/lib/utils';
 
@@ -62,25 +63,24 @@ export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
             getLineProps,
             getTokenProps,
           }) => (
-            <pre
-              {...props}
-              style={{ ...prismStyle, ...style }}
-              ref={ref}
-              className={cn(
-                `max-h-[calc(100dvh-6.5rem)] overflow-auto p-4 text-sm
-leading-relaxed md:max-h-[calc(100dvh-4.5rem)] print:max-h-none
-md:print:max-h-none`,
-                className
-              )}
-            >
-              {tokens.map((line, i) => (
-                <div key={i} {...getLineProps({ line })}>
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({ token })} />
-                  ))}
-                </div>
-              ))}
-            </pre>
+            <ScrollArea className='h-[calc(100dvh-6.5rem)] md:h-[calc(100dvh-4.5rem)]'>
+              <pre
+                {...props}
+                style={{ ...prismStyle, ...style }}
+                ref={ref}
+                className={cn(`p-4 text-sm leading-relaxed`, className)}
+              >
+                {tokens.map((line, i) => (
+                  <div key={i} {...getLineProps({ line })}>
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({ token })} />
+                    ))}
+                  </div>
+                ))}
+              </pre>
+              <ScrollBar orientation='vertical' />
+              <ScrollBar orientation='horizontal' />
+            </ScrollArea>
           )}
         </Highlight>
       </div>

--- a/src/components/ui/CodeBlock/CodeBlock.tsx
+++ b/src/components/ui/CodeBlock/CodeBlock.tsx
@@ -68,8 +68,8 @@ export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
               ref={ref}
               className={cn(
                 `max-h-[calc(100dvh-6.5rem)] overflow-auto p-4 text-sm
-leading-relaxed scrollbar-thin scrollbar-thumb-neutral-500/30
-md:max-h-[calc(100dvh-4.5rem)] print:max-h-none md:print:max-h-none`,
+leading-relaxed md:max-h-[calc(100dvh-4.5rem)] print:max-h-none
+md:print:max-h-none`,
                 className
               )}
             >

--- a/src/components/ui/CodeBlock/CodeBlock.tsx
+++ b/src/components/ui/CodeBlock/CodeBlock.tsx
@@ -63,7 +63,10 @@ export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
             getLineProps,
             getTokenProps,
           }) => (
-            <ScrollArea className='h-[calc(100dvh-6.5rem)] md:h-[calc(100dvh-4.5rem)]'>
+            <ScrollArea
+              className='[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100dvh-6.5rem)]
+md:[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100dvh-4.5rem)]'
+            >
               <pre
                 {...props}
                 style={{ ...prismStyle, ...style }}

--- a/src/components/ui/Fab/Fab.tsx
+++ b/src/components/ui/Fab/Fab.tsx
@@ -18,7 +18,7 @@ export const Fab = forwardRef<HTMLButtonElement, FabProps>(
       {...props}
       ref={ref}
       className={cn(
-        `fixed bottom-4 end-4 z-10 flex h-14 cursor-default select-none
+        `fixed bottom-4 end-4 z-20 flex h-14 cursor-default select-none
 items-center justify-center gap-3 self-center overflow-hidden rounded-lg
 bg-primary-50 text-sm font-medium text-primary-800 shadow shadow-primary-800/50
 state-layer hover:state-layer-primary-500/10 focus-visible:bg-primary-100

--- a/src/components/ui/ScrollArea/ScrollArea.tsx
+++ b/src/components/ui/ScrollArea/ScrollArea.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+} from 'react';
+import {
+  ScrollArea as ScrollAreaRoot,
+  ScrollAreaCorner,
+  ScrollAreaViewport,
+} from '@radix-ui/react-scroll-area';
+
+import { ScrollBar } from './ScrollBar';
+import { cn } from '@/lib/utils';
+
+export const ScrollArea = forwardRef<
+  ElementRef<typeof ScrollAreaRoot>,
+  ComponentPropsWithoutRef<typeof ScrollAreaRoot>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaRoot
+    ref={ref}
+    className={cn('relative overflow-hidden', className)}
+    {...props}
+  >
+    <ScrollAreaViewport className='h-full w-full rounded-[inherit]'>
+      {children}
+    </ScrollAreaViewport>
+    <ScrollBar />
+    <ScrollAreaCorner />
+  </ScrollAreaRoot>
+));
+ScrollArea.displayName = ScrollAreaRoot.displayName;

--- a/src/components/ui/ScrollArea/ScrollBar.tsx
+++ b/src/components/ui/ScrollArea/ScrollBar.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+} from 'react';
+import {
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+} from '@radix-ui/react-scroll-area';
+
+import { cn } from '@/lib/utils';
+
+export const ScrollBar = forwardRef<
+  ElementRef<typeof ScrollAreaScrollbar>,
+  ComponentPropsWithoutRef<typeof ScrollAreaScrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      'flex touch-none select-none transition-colors',
+      orientation === 'vertical' &&
+        'h-full w-2.5 border-l border-l-transparent p-px',
+      orientation === 'horizontal' &&
+        'h-2.5 flex-col border-t border-t-transparent p-px',
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaThumb className='relative flex-1 rounded-full bg-border' />
+  </ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaScrollbar.displayName;

--- a/src/components/ui/ScrollArea/index.ts
+++ b/src/components/ui/ScrollArea/index.ts
@@ -1,0 +1,2 @@
+export * from './ScrollArea';
+export * from './ScrollBar';

--- a/src/lib/codeGen.ts
+++ b/src/lib/codeGen.ts
@@ -57,8 +57,7 @@ ${Object.entries(tokenShades)
   )
   .join('\n')}`;
     })
-    .join('\n\n')}
-}`;
+    .join('\n\n')}`;
 
 export const generateJsonCode = (
   baseColors: Record<string, string>,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -21,6 +21,8 @@
     --color-ring: var(--color-primary-main);
 
     --border-radius: 0.5rem;
+    --scrollbar-height: 0.75rem;
+    --scrollbar-width: 0.75rem;
   }
   @media (prefers-color-scheme: dark) {
     :root {
@@ -65,12 +67,14 @@
     color-scheme: light dark;
   }
   * {
-    @apply border-border;
+    @apply border-border scrollbar scrollbar-track-transparent
+scrollbar-thumb-neutral-500/30;
   }
+
   body {
-    @apply overflow-x-hidden bg-background text-foreground scrollbar-thin
-scrollbar-thumb-neutral-500/30 selection:bg-primary-500/30
-selection:text-primary-950 dark:selection:text-primary-50;
+    @apply overflow-x-hidden bg-background text-foreground
+selection:bg-primary-500/30 selection:text-primary-950
+dark:selection:text-primary-50;
   }
 }
 .lucide {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -40,6 +40,7 @@
       --color-accent-foreground: var(--color-neutral-100);
       --color-border: var(--color-neutral-800);
       --color-input: var(--color-neutral-800);
+      --color-ring: var(--color-primary-300);
     }
   }
   @media print {


### PR DESCRIPTION
Chrome 121 adapted the same CSS properties used in Firefox to style scrollbars - `scrollbar-width` and `scrollbar-color`; These are more limited than the WebKit properties and will take priority over them in Chrome 121.

The WebKit properties still need to be used as Safari doesn’t support the new ones described above.

- Fix page scrollbar styling not working correctly - apply scrollbar styles to `html`
- New `scrollbar-width: thin` is ugly, only apply scrollbar width WebKit properties
- For scrolling elements other than the page, use Radix scroll area

Also fix some other small bugs.